### PR TITLE
refactor: move logica de login para fora do app

### DIFF
--- a/web/src/data/log-rocket.js
+++ b/web/src/data/log-rocket.js
@@ -16,10 +16,8 @@ export const initializeLogRocket = () => {
 // If you use other middlewares, LogRocket should be the final middleware:
 export const logRocketMiddleware = () => LogRocket.reduxMiddleware();
 
-export const identifyUser = (user, additionalInfo) => {
-  LogRocket.identify(user.id, {
-    email: user.email,
-    user,
-    ...additionalInfo
-  });
+export const identifyUser = (user) => {
+  LogRocket.identify(user.id, user);
 };
+
+export const track = event => LogRocket.track(event);

--- a/web/src/domain/index.js
+++ b/web/src/domain/index.js
@@ -1,7 +1,6 @@
 import {
   ReduxAdapter,
   AuthenticationInteractor,
-  configureStore,
 } from 'core';
 import {
   sendPasswordResetEmail,
@@ -9,9 +8,7 @@ import {
   signOut,
   signUpWithEmailAndPassword,
 } from '../data/firebase/authentication';
-import { logRocketMiddleware } from '../data/log-rocket';
-import { isProduction } from './services/environment';
-import locale from "./redux/ducks/localeReducer";
+import { createStore } from './redux';
 
 export const initializeDomainLayer = () => {
   const authenticationInteractor = new AuthenticationInteractor({
@@ -25,13 +22,5 @@ export const initializeDomainLayer = () => {
     authenticationInteractor,
   );
 
-  const middleware = [];
-
-  if (isProduction()) {
-    middleware.push(logRocketMiddleware());
-  }
-
-  const store = configureStore(reduxAdapter, middleware, { locale });
-
-  return { store };
+  return { store: createStore(reduxAdapter) };
 };

--- a/web/src/domain/redux/index.js
+++ b/web/src/domain/redux/index.js
@@ -1,0 +1,20 @@
+import { configureStore } from 'core';
+import { logRocketMiddleware } from '../../data/log-rocket';
+import { isProduction } from '../services/environment';
+import locale from './ducks/localeReducer';
+
+let store = {}
+
+export const createStore = reduxAdapter => {
+  const middleware = [];
+
+  if (isProduction()) {
+    middleware.push(logRocketMiddleware());
+  }
+
+  store = configureStore(reduxAdapter, middleware, { locale });
+
+  return store;
+};
+
+export const dispatch = action => store.dispatch(action);

--- a/web/src/domain/services/monitoring.js
+++ b/web/src/domain/services/monitoring.js
@@ -1,5 +1,7 @@
 import { identifyUser } from '../../data/log-rocket';
 
-export const updateLoggedInUser = (user) => {
-  identifyUser(user);
+export const trackUser = (user) => {
+  if (user) {
+    identifyUser(user);
+  }
 };

--- a/web/src/domain/useCases/user.js
+++ b/web/src/domain/useCases/user.js
@@ -1,0 +1,17 @@
+import { setUserListenerAction, User } from 'core';
+import { trackUser } from '../services/monitoring';
+import { dispatch } from '../redux';
+
+export const whenUserLogsIn = user => {
+  const authedUser = new User(user.uid, user.email, {
+    emailVerified: user.emailVerified,
+  });
+
+  dispatch(setUserListenerAction(authedUser))
+  trackUser(authedUser);
+};
+
+export const whenUserLogsOut = () => {
+  dispatch(setUserListenerAction(null))
+  trackUser(null);
+};

--- a/web/src/presentation/App.js
+++ b/web/src/presentation/App.js
@@ -1,38 +1,33 @@
-import { updateLoggedInUser } from '../domain/services/monitoring';
 import { onAuthStateChanged } from '../data/firebase/authentication';
 import { IntlProvider } from 'react-intl';
 import { Router } from './Router';
 import PropTypes from 'prop-types';
-import React,{ Component } from 'react';
-import './App.css'
+import React, { Component } from 'react';
+import './App.css';
 import { connect } from 'react-redux';
 import { localeSelector } from '../domain/redux/ducks/localeReducer';
-import { User, setUserListenerAction } from 'core';
+import { whenUserLogsIn, whenUserLogsOut } from '../domain/useCases/user';
 
 class AppContainer extends Component {
-
   unsubscribe = () => {};
 
-  setUser = (user) => {
-    let authedUser;
-
+  userHasChangedCallback = user => {
     if (user) {
-      authedUser = new User(user.uid, user.email, { emailVerified: user.emailVerified});
+      whenUserLogsIn(user);
+    } else {
+      whenUserLogsOut();
     }
-
-    this.props.setUserListener(authedUser);
-    updateLoggedInUser(authedUser);
   };
 
   componentDidMount() {
-    this.unsubscribe = onAuthStateChanged(this.setUser)
+    this.unsubscribe = onAuthStateChanged(this.userHasChangedCallback);
   }
 
   render() {
     const { messages, locale } = this.props;
 
     return (
-      <IntlProvider key={locale} locale={locale} messages={messages[locale]} >
+      <IntlProvider key={locale} locale={locale} messages={messages[locale]}>
         <Router />
       </IntlProvider>
     );
@@ -40,22 +35,14 @@ class AppContainer extends Component {
 }
 
 const mapStateToProps = state => ({
-  locale: localeSelector(state)
+  locale: localeSelector(state),
 });
-
-const mapDispatchToProps = {
-  setUserListener : setUserListenerAction
-};
 
 AppContainer.propTypes = {
   messages: PropTypes.object.isRequired,
   locale: PropTypes.string.isRequired,
-  setUserListener: PropTypes.func.isRequired
 };
 
 AppContainer.displayName = 'App';
 
-export const App = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(AppContainer);
+export const App = connect(mapStateToProps)(AppContainer);


### PR DESCRIPTION
A implementação atual está 100% correta, eu só quero testar uma coisa e ver se no longo prazo vale a pena.
 A ideia é manter o máximo de lógica possível fora do React, com isso os componentes deverão ficar riducilamente simples de se entender e de testar também. A desvantagem disso é que a lógica vai estar um clique distante do componente, ou seja, olhando somente o componente vai ser dificil saber exatamente o que está acontecendo, sempre vai precisar de ir no método do dominio que contem a lógica de négocio.